### PR TITLE
quickstart: rewrite with widgets

### DIFF
--- a/docs/source/quickstart.lisp
+++ b/docs/source/quickstart.lisp
@@ -6,6 +6,12 @@
   (:use #:cl
         #:weblocks-ui/form
         #:weblocks/html)
+  (:import-from #:weblocks/widget
+                #:render
+                #:update
+                #:defwidget)
+  (:import-from #:weblocks/actions
+                #:make-js-action)
   (:import-from #:weblocks/app
                 #:defapp))
 (in-package todo)
@@ -16,100 +22,107 @@
 (weblocks/debug:on)
 
 (defvar *port* (find-port:find-port))
+
+(weblocks/app:start 'tasks)
 (weblocks/server:start :port *port*)
 
-;; Part 2
+;; Part 2: defining tasks
+
+
+(defwidget task ()
+    ((title
+      :initarg :title
+      :reader title)
+     (done
+      :initarg :done
+      :initform nil
+      :accessor done)))
+
+(defmethod print-object ((task task) stream)
+  (print-unreadable-object (task stream :type t)
+    (format stream "~a, done ? ~a" (title task) (done task))))
+
+(defvar *task-1* (make-instance 'task :title "Make my first Weblocks app"))
+
+(defmethod render ((task task))
+  (with-html
+    (:span (if (done task)
+               (with-html
+                 (:s (title task)))
+               (title task)))))
+
+
+(defun make-task (&key title done)
+  "Create a task."
+  (make-instance 'task :title title :done done))
+
+(defwidget task-list ()
+  ((tasks
+    :initarg :tasks
+    :accessor tasks)))
+
+(defmethod render ((widget task-list))
+  (with-html
+    (:h1 "Tasks")
+    (:ul
+     (loop for task in (tasks widget) do
+          (:li (render task))))))
+
+(defvar *root* nil
+  "Our root widget.")
 
 (defmethod weblocks/session:init ((app tasks))
-  (let ((tasks '("Make my first app in Weblocks"
-                 "Deploy it somewhere"
-                 "Have a profit")))
-    (lambda ()
-      (with-html
-        (:h1 "Tasks")
-        (:ul :class "tasks"
-             (loop for task in tasks
-                   do (with-html
-                        (:li task))))))))
+  (declare (ignorable app))
+  (let ((tasks (list (make-task :title "Make my first Weblocks app")
+                     (make-task :title "Deploy it somewhere")
+                     (make-task :title "Have a profit"))))
+    (setf *root* (make-instance 'task-list :tasks tasks))))
 
 (weblocks/debug:reset-latest-session)
 
 
-;; Part 3
+;; Part 3: add-task
 
-(defmethod weblocks/session:init ((app tasks))
-  (let ((tasks '("Make my first app in Weblocks"
-                 "Deploy it somewhere"
-                 "Have a profit")))
-    (flet ((add-task (&key task &allow-other-keys)
-             (push task tasks)
-             (weblocks/widget:update
-                 (weblocks/widgets/root:get))))
-      (lambda ()
-        (with-html
-          (:h1 "Tasks")
-          (:ul :class "tasks"
-               (loop for task in tasks
-                     do (with-html
-                          (:li task))))
-          (with-html-form (:POST #'add-task)
-            (:input :type "text"
-                    :name "task"
-                    :placeholder "Task's title")
-            (:input :type "submit"
-                    :value "Add")))))))
+(defun add-task (&rest rest &key title &allow-other-keys)
+  (push (make-task :title title) (tasks *root*))
+  (update *root*))
+
+(defmethod render ((widget task-list))
+  (with-html
+    (:h1 "Tasks")
+    (loop for task in (tasks widget) do
+         (render task))
+    (with-html-form (:POST #'add-task)
+      (:input :type "text"
+              :name "title"
+              :placeholder "Task's title")
+      (:input :type "submit"
+              :value "Add"))))
 
 (weblocks/debug:reset-latest-session)
 
 
-;; Part 4
+;; Part 4: toggle
 
-(defstruct task
-  (title)
-  (done))
+(defmethod toggle ((task task))
+  (setf (done task)
+        (if (done task)
+            nil
+            t))
+  (update task))
 
+(defmethod render ((task task))
+  (with-html
+    (:p (:input :type "checkbox"
+                :checked (done task)
+                :onclick (make-js-action
+                          (lambda (&rest rest)
+                            (declare (ignore rest))
+                            (toggle task))))
+        (:span (if (done task)
+                   (with-html
+                     (:s (title task)))
+                   (title task))))))
 
-(defmethod weblocks/session:init ((app tasks))
-  (let ((tasks (list (make-task :title "Make my first app in Weblocks" :done t)
-                     (make-task :title "Deploy it somewhere" :done nil)
-                     (make-task :title "Have a profit" :done nil))))
-    (labels ((redraw ()
-               (weblocks/widget:update
-                   (weblocks/widgets/root:get)))
-             (add-task (&rest rest &key task &allow-other-keys)
-               (log:info "Pushing" task "to" tasks rest)
-               (push (make-task :title task :done nil) tasks)
-               (redraw))
-             (toggle-task (task)
-               (setf (task-done task)
-                     (if (task-done task)
-                         nil
-                         t))
-               (redraw))
-             (render-task (task)
-               (let ((title (task-title task))
-                     (done (task-done task)))
-                 (with-html
-                   (:p (:input :type "checkbox"
-                               :checked done
-                               :onclick (weblocks/actions:make-js-action
-                                         (lambda (&rest rest)
-                                           (declare (ignore rest))
-                                           (toggle-task task))))
-                       (:span (if done
-                                  (with-html (:s title))
-                                  title)))))))
-      (lambda ()
-        (with-html
-          (:h1 "Tasks")
-          (:div :class "tasks"
-                (loop for task in tasks
-                      do (with-html (render-task task))))
-          (with-html-form (:POST #'add-task)
-            (:input :type "text"
-                    :name "task"
-                    :placeholder "Task's title")
-            (:input :type "submit"
-                    :value "Add")))))))
 
 (weblocks/debug:reset-latest-session)

--- a/src/dependencies.lisp
+++ b/src/dependencies.lisp
@@ -313,7 +313,7 @@ by infering it from URL or a path"))
                                       crossorigin)
   "Creates a JavaScript dependency, served from the disk.
 
-If system's name was give, then path is calculated relative
+If the system's name is given, then the path is calculated relatively
 to this system's source root."
   (check-type path-or-url (or string pathname))
 

--- a/src/widgets/base.lisp
+++ b/src/widgets/base.lisp
@@ -130,10 +130,10 @@ inherits from 'widget' if no direct superclasses are provided."
 
 Usually this required as a result of an action execution.
 
-In old weblocks there was a mark-dirty method. This one replaces it.
-To make everything easier, new protocol excludes \"propagation\". If you
-need to update other widgets, please define \"update\" method for you widget.
-You can use :before or :after modifier, to keep current behavior and to add
+In the old weblocks there was a mark-dirty method. This one replaces it.
+To make everything easier, the new protocol excludes \"propagation\". If you
+need to update other widgets, please define an \"update\" method for your widget.
+You can use :before or :after modifiers, to keep the current behavior and to add
 propagation code."))
 
 


### PR DESCRIPTION
I suggest to rewrite the quickstart with widgets. It was needed, so why not teach the heart of Weblocks right away. And there are no large code blocks anymore.

I kept the progression with first a list of tasks, then adding one, then toggle its state.

I added links to Practical CL and the Cookbook to get familiar with CLOS and databases.

I find it amazingly simple how we just need to write a render function for our widgets to get started. Still hooked :) 