### PR TITLE
Export weblocks/js/jquery:jquery-backend

### DIFF
--- a/src/js/jquery.lisp
+++ b/src/js/jquery.lisp
@@ -7,7 +7,8 @@
                 #:get-dependencies
                 #:make-dependency)
   ;; Just dependencies
-  (:import-from #:log))
+  (:import-from #:log)
+  (:export #:jquery-backend))
 (in-package weblocks/js/jquery)
 
 


### PR DESCRIPTION
This lets me extend the jquery-backend with custom additional functions without having to copy paste the whole jquery backend.