### PR TITLE
Added a type check on the render method

### DIFF
--- a/src/widgets/render-methods.lisp
+++ b/src/widgets/render-methods.lisp
@@ -34,6 +34,7 @@
 (defmethod render :around (widget)
   "This function is intended for internal usage only.
    It renders widget with surrounding HTML tag and attributes."
+  (check-type widget weblocks/widgets/base:widget)
   (log:debug "Rendering widget" widget "with" (get-collected-dependencies))
   
   (let ((widget-dependencies (get-dependencies widget)))


### PR DESCRIPTION
in order to get more explicit error messages.

As a beginner it is easy to call render on an object that is not a Weblocks widget.

before:

There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION WEBLOCKS/WIDGETS/DOM:DOM-ID (4)>
when called with arguments
  (#<MY.MODELS:CLASS Foo>).

now:

The value of WEBLOCKS/WIDGETS/RENDER-METHODS::WIDGET is #<MY.MODELS:CLASS Foo>, which is not of type WEBLOCKS/WIDGETS/BASE:WIDGET.