### PR TITLE
Quickstart: mention defapp prefix

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,8 @@ dev
 Changes
 -------
 
+* Added a log in ``weblocks/app:start`` to show the prefix of the app
+  that is started.
 * Changed ``(weblocks/debug:on)`` and ``off`` so they set the log
   level to ``debug`` and ``warn``, respectively.
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,16 @@
  ChangeLog
 ===========
 
+dev
+===
+
+Changes
+-------
+
+* Changed ``(weblocks/debug:on)`` and ``off`` so they set the log
+  level to ``debug`` and ``warn``, respectively.
+
+
 0.39.1 (2020-01-20)
 ===================
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -38,6 +38,21 @@ Now, create an application:
 .. code-block:: common-lisp-repl
 
    TODO> (defapp tasks)
+
+By default, the name of the app defines the url where it is
+accessible. Here, the "tasks" app will be accessible under
+``http://localhost:40000/tasks``. We can change it with the
+``:prefix`` argument:
+
+.. code-block:: common-lisp-repl
+
+   TODO> (defapp tasks
+            :prefix "/")
+
+Now our app runs under the root url.
+
+.. code-block:: common-lisp-repl
+
    TODO> (weblocks/debug:on)
    TODO> (defvar *port* (find-port:find-port))
    TODO> (weblocks/server:start :port *port*)

--- a/docs/source/routing.rst
+++ b/docs/source/routing.rst
@@ -3,9 +3,8 @@
 ============
 
 In the quickstart tutorial, we saw how to create and render widgets,
-and how to react to user events. We also saw that the name of the app
-defined its base URL: the ``tasks`` app was accessible under
-``localhost:8080/tasks/``.
+and how to react to user events. We also learned that by default the
+app name defined its base url, and how to change it.
 
 Here, we will extend the example and make each task accessible under
 ``/tasks/<task id>``.
@@ -25,9 +24,6 @@ Weblocks:
 
 * ``weblocks/session:init`` must return an instance of the route
   widget, using the ``make-tasks-routes`` constructor created by ``defroutes``.
-
-* to change the base URL (``localhost:8080/tasks/``,
-  ``localhost:8080/foo/``), create a new app.
 
 Let's start. Note that you can see the full code `on Github
 <https://github.com/40ants/weblocks/blob/reblocks/docs/source/routing.lisp>`_.

--- a/src/app.lisp
+++ b/src/app.lisp
@@ -292,6 +292,7 @@ called (primarily for backward compatibility"
        (let ((app (apply #'make-instance class initargs)))
          (initialize-webapp app)
          (enable-webapp app)
+         (log:debug "~a started on url ~a" (webapp-name app) (get-prefix app))
          app)))))
 
 

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -88,6 +88,7 @@ To clear, use function \(reset-last-session\).")
           (getf *config* :invoke-debugger-on-error)
           t))
 
+  (log:config :debug)
 
   (values))
 
@@ -110,6 +111,9 @@ To clear, use function \(reset-last-session\).")
           nil))
   
   (setf *config* nil)
+
+  (log:config :warn)
+
   (values))
 
 


### PR DESCRIPTION
Related to #27 

I also suggest to change the log level to follow the idea of `weblocks/debug:on/off`. Maybe it makes things clearer (now we show the app's url), maybe not:

level warn:
```
TODO> (weblocks/app:start 'weblocks/default-init:welcome-screen-app)
#<WEBLOCKS/DEFAULT-INIT:WELCOME-SCREEN-APP {10064D1A43}>
```

level debug:
```
TODO> (weblocks/app:start 'weblocks/default-init:welcome-screen-app)
<DEBUG> [22:39:47] weblocks/app app.lisp (start) -
  Starting webapp CLASS: WEBLOCKS/DEFAULT-INIT:WELCOME-SCREEN-APP
  WEBLOCKS/APP::INITARGS: NIL WEBLOCKS/APP::NAME: "welcome-screen-app" 
<DEBUG> [22:39:47] weblocks/app app.lisp (enable-webapp) -
  Enabling webapp WEBLOCKS/APP:APP: #<WEBLOCKS/DEFAULT-INIT:WELCOME-SCREEN-APP {1005F9EB33}>
  
<DEBUG> [22:39:47] weblocks/app app.lisp (start) -
  welcome-screen-app started on url /
#<WEBLOCKS/DEFAULT-INIT:WELCOME-SCREEN-APP {1005F9EB33}>
```

Just thought now: we could set the log level to `:info` and only print "app started on url …".