### PR TITLE
[WIP] Welcome screen app

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -10,6 +10,9 @@ Changes
 -------
 
 * Added a welcome screen app on "/" that lists the active apps.
+* ``create-widget-from`` now returns a more user-friendly error
+  message, explaining that the widget is not of a good type, instead
+  of "no applicable generic method".
 
 0.39.1 (2020-01-20)
 ===================

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,15 @@
  ChangeLog
 ===========
 
+
+0.39.2 (2020-02-11)
+===================
+
+Changes
+-------
+
+* Added a welcome screen app on "/" that lists the active apps.
+
 0.39.1 (2020-01-20)
 ===================
 
@@ -14,7 +23,7 @@ Fixed
 
   https://github.com/fukamachi/woo/issues/84
 
-  Now Woo does not parses numberic headers and Weblocks has to do it itself.
+  Now Woo does not parses numeric headers and Weblocks has to do it itself.
 
 0.39.0 (2019-09-16)
 ===================

--- a/src/default-init.lisp
+++ b/src/default-init.lisp
@@ -1,5 +1,14 @@
 (defpackage #:weblocks/default-init
   (:use #:cl)
+  (:import-from #:weblocks/app
+                #:app-active-p
+                #:get-active-apps
+                #:get-prefix
+                #:webapp-name
+                #:defapp)
+  (:import-from #:weblocks/widget
+                #:render
+                #:defwidget)
   (:import-from #:weblocks/session
                 #:init)
   (:import-from #:weblocks/widget
@@ -9,8 +18,11 @@
                 #:with-html-string)
   (:import-from #:weblocks/widgets/string-widget
                 #:make-string-widget)
+  (:import-from #:weblocks/html
+                #:with-html)
   (:import-from #:weblocks/app
-                #:*current-app*))
+                #:*current-app*)
+  (:export #:welcome-screen-app))
 (in-package weblocks/default-init)
 
 
@@ -38,3 +50,49 @@
 
   (let ((root (call-next-method)))
     (create-widget-from root)))
+
+(defapp welcome-screen-app
+    :prefix "/")
+
+(defparameter *welcome-screen-enabled* t
+  "If t, show the welcome screen on the root url, if no other widget use the path.")
+
+(defwidget welcome-screen-widget ()
+  ())
+
+(defmethod render ((widget welcome-screen-widget))
+  (let ((apps (weblocks/app:get-active-apps)))
+    (with-html
+      (:h1 "Welcome to Weblocks!")
+      (:div "To learn more about Weblocks, head over its "
+            (:a :href "http://40ants.com/weblocks/" "documentation.")
+            " To learn how to create apps and widgets, see the "
+            (:a :href "http://40ants.com/weblocks/quickstart.html" "quickstart guide")
+            ".")
+      (:h3)
+      (when apps
+        (:div "You also have active apps, congratulations! You are running:")
+        (loop for app in apps
+           do
+             (let ((prefix (get-prefix app)))
+               (:ul
+                (:li
+                 (:a :href prefix (format nil "~a" (weblocks/app::webapp-name app)))
+                 (:span (format nil " on \"~a\"" prefix))))))
+
+        (:h3)
+        (when (app-active-p 'welcome-screen-app)
+          (:div "This is the welcome screen, a Weblocks app itself.")
+          (:div "If you want to stop it, do:")
+          (:code "(weblocks/app:stop 'weblocks/default-init:welcome-screen-app)")
+          (:div "And in case you want to disable it before the server starts, do:")
+          (:code "(setf weblocks/default-init::*welcome-screen-enabled* nil)")
+          (:h3)
+          (:div "If you want to bind your app to \"/\", use the prefix argument of defapp:")
+          (:code "(defapp myapp :prefix \"/\")"))))))
+
+(defmethod weblocks/session:init ((app welcome-screen-app))
+  (make-instance 'welcome-screen-widget))
+
+(when *welcome-screen-enabled*
+  (weblocks/app:start 'welcome-screen-app))

--- a/src/widgets/base.lisp
+++ b/src/widgets/base.lisp
@@ -177,3 +177,7 @@ propagation code."))
   "If input is already a widget, then it is returned as is."
   object)
 
+(defmethod create-widget-from ((object t))
+  "If this method is called, that means that object is not of a proper type. Say it
+with an explicit error message."
+  (error "We tried to create a widget from ~a but this object type is not recognized. Did you forget to create a widget?~&There is no applicable method for CREATE-WIDGET-FROM." object))


### PR DESCRIPTION
Weblocks now shows a welcome screen on "/" instead of "/: file not found".

for #27 

![Selection_036](https://user-images.githubusercontent.com/3721004/74218939-99b33a80-4cab-11ea-9bc2-ada7b04ebb05.png)


WIP because:

- I have trouble running two apps at the same time: "/tasks" also shows the welcome screen, also when it is stopped (with `(weblocks/app:stop 'weblocks/default-init:welcome-screen-app)`).
- I didn't try yet starting an app on the "/" prefix (it is supposed to be just one).