### PR TITLE
Changed a library used to log unhandled errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ cache:
 before_script:
   - env | sort
   - ros --version
-  - ros install asdf/3.3.1.1
+  - ros install asdf
   # Version fixed for more build stability
   # TODO: update it from time to time
   - ros install 40ants/qlot/freeze/6fdc1ca4778a905870b6c7bbbd598b3966d53453
@@ -66,7 +66,8 @@ before_script:
   - ros install Shinmera/dissect
   - ros install fukamachi/rove
   - ros install 40ants/cl-info
-  
+
+  - rm qlfile.lock # to always check weblocks on latest versions of quicklisp and ultralisp
   - qlot install --no-deps
   - qlot exec ros run -e '(progn (ql:quickload :weblocks-test) (uiop:quit 0))'
   - qlot exec cl-info hamcrest rove dissect weblocks

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,7 @@ Changes
   that is started.
 * Changed ``(weblocks/debug:on)`` and ``off`` so they set the log
   level to ``debug`` and ``warn``, respectively.
+* Changed a library used to log unhandled errors. Now `log4cl-extras <https://github.com/40ants/log4cl-extras>`_ is used, because it is a successor of `log4cl-json <https://github.com/40ants/log4cl-json>`_.
 
 
 0.39.1 (2020-01-20)

--- a/src/request-handler.lisp
+++ b/src/request-handler.lisp
@@ -78,7 +78,7 @@
   (:import-from #:weblocks/session)
   (:import-from #:alexandria
                 #:make-keyword)
-  (:import-from #:log4cl-json
+  (:import-from #:log4cl-extras/error
                 #:with-log-unhandled)
 
   (:export


### PR DESCRIPTION
Now log4cl-extras is used, because it is a successor of log4cl-json.